### PR TITLE
fix typo in prestige V config description

### DIFF
--- a/src/main/java/fr/alexdoru/megawallsenhancementsmod/gui/MWEnConfigGuiScreen.java
+++ b/src/main/java/fr/alexdoru/megawallsenhancementsmod/gui/MWEnConfigGuiScreen.java
@@ -150,8 +150,8 @@ public class MWEnConfigGuiScreen extends MyGuiScreen implements GuiSlider.ISlide
                 break;
             case 24:
                 textLines.add(EnumChatFormatting.GREEN + "Adds the prestige V colored tags in mega walls");
-                textLines.add(EnumChatFormatting.GREEN + "You need at least" + EnumChatFormatting.GOLD + " 1 000 000 coins" + EnumChatFormatting.GREEN + ", " + EnumChatFormatting.GOLD + " 7500 classpoints" + EnumChatFormatting.GREEN + ",");
-                textLines.add(EnumChatFormatting.GREEN + "and a " + EnumChatFormatting.DARK_RED + "valid API Key" + EnumChatFormatting.GREEN + ". This will send api requests and store the data");
+                textLines.add(EnumChatFormatting.GREEN + "You need at least" + EnumChatFormatting.GOLD + " 1 000 000 coins" + EnumChatFormatting.GREEN + ", " + EnumChatFormatting.GOLD + " 10 000 classpoints" + EnumChatFormatting.GREEN + ",");
+                textLines.add(EnumChatFormatting.GREEN + "and a " + EnumChatFormatting.DARK_RED + "working API Key" + EnumChatFormatting.GREEN + ". This will send api requests and store the data");
                 textLines.add(EnumChatFormatting.GREEN + "in a cache until you close your game.");
                 textLines.add(EnumChatFormatting.GREEN + "Type " + EnumChatFormatting.YELLOW + "/mwenhancements clearcache" + EnumChatFormatting.GREEN + " to force update the data");
                 textLines.add("");


### PR DESCRIPTION
(cherry picked from commit 91db05e3f03e1848e61ee63a79834dd5fd3432cc)